### PR TITLE
provide Manifest info during deserialization

### DIFF
--- a/src/Akka.Persistence.AzureTable/Journal/AzureTableJournal.cs
+++ b/src/Akka.Persistence.AzureTable/Journal/AzureTableJournal.cs
@@ -211,9 +211,9 @@ namespace Akka.Persistence.AzureTable.Journal
             return new JournalEntry(message.PersistenceId, message.SequenceNr, payload, message.Payload.GetType().TypeQualifiedNameForManifest());
         }
 
-        private Persistent ToPersistenceRepresentation(JournalEntry entry, IActorRef sender)
+        private static Persistent ToPersistenceRepresentation(JournalEntry entry, IActorRef sender)
         {
-            var payload = JsonConvert.DeserializeObject(entry.Payload);
+            var payload = JsonConvert.DeserializeObject(entry.Payload, Type.GetType(entry.Manifest));
             return new Persistent(payload, long.Parse(entry.RowKey), entry.PartitionKey, entry.Manifest, false, sender);
         }
     }


### PR DESCRIPTION
In order to deserialize payload correctly, type information must be provided to JsonConvert. Otherwise JObject is created.
The other approach would be to include type information during serialization providing `JsonSerializerSettings.TypeNameHandling.Objects`.
