### PR TITLE
Strip PersistenceId from illegal Azure Table characters

### DIFF
--- a/src/Akka.Persistence.AzureTable.Tests/Akka.Persistence.AzureTable.Tests.csproj
+++ b/src/Akka.Persistence.AzureTable.Tests/Akka.Persistence.AzureTable.Tests.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AzureTableJournalSpec.cs" />
     <Compile Include="AzureTableSettingsSpec.cs" />
+    <Compile Include="TableExtensionsSpec.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/src/Akka.Persistence.AzureTable.Tests/TableExtensionsSpec.cs
+++ b/src/Akka.Persistence.AzureTable.Tests/TableExtensionsSpec.cs
@@ -1,0 +1,14 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace Akka.Persistence.AzureTable.Tests
+{
+    public class TableExtensionsSpec
+    {
+        [Fact]
+        public void ShoulReplaceDisallowedChars_should_replace_slashes()
+        {
+            "/user/actor1/actor2".ReplaceDisallowedChars().Should().Be("-user-actor1-actor2");
+        }
+    }
+}

--- a/src/Akka.Persistence.AzureTable/Akka.Persistence.AzureTable.csproj
+++ b/src/Akka.Persistence.AzureTable/Akka.Persistence.AzureTable.csproj
@@ -102,6 +102,7 @@
     <Compile Include="SerializerExtensions.cs" />
     <Compile Include="Snapshot\AzureSnapshotStore.cs" />
     <Compile Include="Snapshot\SnapshotEntry.cs" />
+    <Compile Include="TableKeyExtenstions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Akka.Persistence.AzureTable.nuspec" />

--- a/src/Akka.Persistence.AzureTable/Journal/JournalEntry.cs
+++ b/src/Akka.Persistence.AzureTable/Journal/JournalEntry.cs
@@ -18,7 +18,7 @@ namespace Akka.Persistence.AzureTable.Journal
 
         public JournalEntry(string persistenceId, long sequenceNr, string payload, string manifest)
         {
-            PartitionKey = persistenceId;
+            PartitionKey = persistenceId.ReplaceDisallowedChars();
             RowKey = ToRowKey(sequenceNr);
 
             Payload = payload;

--- a/src/Akka.Persistence.AzureTable/Journal/MetadataEntry.cs
+++ b/src/Akka.Persistence.AzureTable/Journal/MetadataEntry.cs
@@ -15,7 +15,7 @@ namespace Akka.Persistence.AzureTable.Journal
 
         public MetadataEntry(string persistenceId, long sequenceNr)
         {
-            PartitionKey = persistenceId;
+            PartitionKey = persistenceId.ReplaceDisallowedChars();
             RowKey = persistenceId;
 
             SequenceNr = sequenceNr;

--- a/src/Akka.Persistence.AzureTable/Snapshot/AzureSnapshotStore.cs
+++ b/src/Akka.Persistence.AzureTable/Snapshot/AzureSnapshotStore.cs
@@ -50,7 +50,9 @@ namespace Akka.Persistence.AzureTable.Snapshot
         {
             var table = _client.Value.GetTableReference(_settings.TableName);
 
-            var query = BuildSnapshotTableQuery(persistenceId.ReplaceDisallowedChars(), criteria);
+            var query = BuildSnapshotTableQuery(
+                persistenceId.ReplaceDisallowedChars(), 
+                criteria);
 
             return table.ExecuteQuery(query).OrderByDescending(t => t.RowKey).Select(ToSelectedSnapshot).FirstOrDefault();
         }
@@ -119,7 +121,10 @@ namespace Akka.Persistence.AzureTable.Snapshot
         private static TableQuery<SnapshotEntry> BuildSnapshotTableQuery(string persistenceId, SnapshotSelectionCriteria criteria)
         {
             string comparsion = TableQuery.CombineFilters(
-                TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, persistenceId.ReplaceDisallowedChars()),
+                TableQuery.GenerateFilterCondition(
+                    "PartitionKey", 
+                    QueryComparisons.Equal, 
+                    persistenceId.ReplaceDisallowedChars()),
                 TableOperators.And,
                 TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.LessThanOrEqual, SnapshotEntry.ToRowKey(criteria.MaxSequenceNr)));
 
@@ -138,7 +143,7 @@ namespace Akka.Persistence.AzureTable.Snapshot
         {
             var payload = JsonConvert.SerializeObject(snapshot);
             return new SnapshotEntry(
-                metadata.PersistenceId.ReplaceDisallowedChars(), 
+                metadata.PersistenceId, 
                 metadata.SequenceNr, 
                 metadata.Timestamp.Ticks, 
                 snapshot.GetType().TypeQualifiedNameForManifest(), 

--- a/src/Akka.Persistence.AzureTable/Snapshot/SnapshotEntry.cs
+++ b/src/Akka.Persistence.AzureTable/Snapshot/SnapshotEntry.cs
@@ -15,7 +15,7 @@ namespace Akka.Persistence.AzureTable.Snapshot
 
         public SnapshotEntry(string persistenceId, long sequenceNr, long snapshotTimestamp, string manifest, string payload)
         {
-            PartitionKey = persistenceId;
+            PartitionKey = persistenceId?.ReplaceDisallowedChars();
             RowKey = ToRowKey(sequenceNr);
 
             SnapshotTimestamp = snapshotTimestamp;

--- a/src/Akka.Persistence.AzureTable/TableKeyExtenstions.cs
+++ b/src/Akka.Persistence.AzureTable/TableKeyExtenstions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Akka.Persistence.AzureTable
+{
+    public static class TableKeyExtenstions
+    {
+        private static readonly Regex DisallowedCharsInTableKeys = new Regex(@"[\\\\#%+/?\u0000-\u001F\u007F-\u009F]", RegexOptions.Compiled);
+
+        public static string ReplaceDisallowedChars(this string key, string replaceWith = "-")
+        {
+            return DisallowedCharsInTableKeys.Replace(key, replaceWith);
+        }
+    }
+}


### PR DESCRIPTION
It seems like PersistenceId some times (when using Cluster) can contain '/'. This strips the illegal characters and replaces them with '-'.